### PR TITLE
feat(api): add API versioning and move controllers to versioned folders

### DIFF
--- a/Movies.Api/Controllers/V1/MoviesController.cs
+++ b/Movies.Api/Controllers/V1/MoviesController.cs
@@ -8,10 +8,11 @@ using Movies.Application.Services;
 using Movies.Contracts.Requests;
 using Movies.Contracts.Responses;
 
-namespace Movies.Api.Controllers
+namespace Movies.Api.Controllers.V1
 {
 
     [ApiController]
+    [ApiVersion("1.0")]
     public class MoviesController : ControllerBase
     {
         private readonly IMovieService _movieService;
@@ -43,6 +44,7 @@ namespace Movies.Api.Controllers
             
             return Ok(response);
         }
+
 
         [HttpGet(ApiEndpoints.Movies.Get)]
         public async Task<IActionResult> Get([FromRoute] string idOrSlug, CancellationToken cancellationToken)

--- a/Movies.Api/Controllers/V1/RatingsController.cs
+++ b/Movies.Api/Controllers/V1/RatingsController.cs
@@ -6,9 +6,10 @@ using Movies.Api.Mapping;
 using Movies.Application.Services;
 using Movies.Contracts.Requests;
 
-namespace Movies.Api.Controllers;
+namespace Movies.Api.Controllers.V1;
 
 [ApiController]
+[ApiVersion("1.0")]
 public class RatingController : ControllerBase
 {
     private readonly IRatingService _ratingService;

--- a/Movies.Api/Controllers/V2/MoviesController.cs
+++ b/Movies.Api/Controllers/V2/MoviesController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Movies.Api.Auth;
+using Movies.Api.Mapping;
+using Movies.Application.Repositories;
+using Movies.Application.Services;
+using Movies.Contracts.Requests;
+using Movies.Contracts.Responses;
+
+namespace Movies.Api.Controllers.V2
+{
+
+    [ApiController]
+    [ApiVersion("2.0")]
+    public class MoviesController : ControllerBase
+    {
+        private readonly IMovieService _movieService;
+        public MoviesController(IMovieService movieService)
+        {
+            _movieService = movieService;
+        }
+
+        [HttpGet(ApiEndpoints.Movies.Get)]
+        public async Task<IActionResult> Get([FromRoute] string idOrSlug, CancellationToken cancellationToken)
+        {
+            var userId = HttpContext.GetUserId();
+            var movie = Guid.TryParse(idOrSlug, out var id)
+                ? await _movieService.GetByIdAsync(id, userId, cancellationToken)
+                : await _movieService.GetBySlugAsync(idOrSlug, userId, cancellationToken);
+
+            if (movie is null)
+            {
+                return NotFound();
+            }
+            var response = movie.MapToResponse();
+            return Ok(response);
+        }
+    }
+}

--- a/Movies.Api/Movies.Api.csproj
+++ b/Movies.Api/Movies.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
   </ItemGroup>
 

--- a/Movies.Api/Program.cs
+++ b/Movies.Api/Program.cs
@@ -1,5 +1,8 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.IdentityModel.Tokens;
 using Movies.Api;
 using Movies.Api.Mapping;
@@ -37,11 +40,19 @@ builder.Services.AddAuthorization(options =>
 
     options.AddPolicy(AuthContstants.TrusterMemberPolicyName, policy =>
     {
-        policy.RequireAssertion(c => 
-            c.User.HasClaim(AuthContstants.TrusterMemberClaimName,"true") ||
+        policy.RequireAssertion(c =>
+            c.User.HasClaim(AuthContstants.TrusterMemberClaimName, "true") ||
             c.User.HasClaim(AuthContstants.AdminUserClaimName, "true")
-        );    
+        );
     });
+});
+
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.ReportApiVersions = true;
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ApiVersionReader = new MediaTypeApiVersionReader("api-version");
 });
 
 // Add services to the container.


### PR DESCRIPTION
- Add [ApiVersion] attribute to controllers
- Move controllers to V1 and V2 folders
- Update Program.cs and project file for versioning support
- Refactor endpoints and registration for versioned API structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced API versioning support, allowing clients to specify API versions via media type headers.
  - Added a new version 2.0 Movies endpoint with improved movie retrieval by ID or slug.

- **Chores**
  - Updated API controllers to include versioning attributes and reorganized namespaces to support versioned endpoints.
  - Added a dependency for API versioning to the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->