### PR TITLE
feat: implement output caching for movie endpoints

### DIFF
--- a/Movies.Api/Cache/CacheConstants.cs
+++ b/Movies.Api/Cache/CacheConstants.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Movies.Api.Cache;
+
+public static class CacheConstants
+{
+    public const string MovieCachePolicy = "MovieCache";
+    public const string MovieCacheTag = "movies";
+    
+    public static readonly string[] MovieCacheVaryByQueryParams = new[]
+    {
+        "title",
+        "year",
+        "sortBy",
+        "page",
+        "pageSize"
+    };
+}

--- a/Movies.Api/Controllers/V1/MoviesController.cs
+++ b/Movies.Api/Controllers/V1/MoviesController.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
 using Movies.Api.Auth;
+using Movies.Api.Cache;
 using Movies.Api.Mapping;
-using Movies.Application.Repositories;
 using Movies.Application.Services;
 using Movies.Contracts;
 using Movies.Contracts.Requests;
@@ -22,8 +22,8 @@ namespace Movies.Api.Controllers.V1
 
         public MoviesController(IMovieService movieService, IOutputCacheStore outputCacheStore)
         {
-            _outputCacheStore = outputCacheStore;
             _movieService = movieService;
+            _outputCacheStore = outputCacheStore;
         }
 
         [Authorize(AuthContstants.TrusterMemberPolicyName)]
@@ -34,15 +34,15 @@ namespace Movies.Api.Controllers.V1
         {
             var movie = movieRequest.MapToMovie();
             await _movieService.CreateAsync(movie, cancellationToken);
-            await _outputCacheStore.EvictByTagAsync("movies", cancellationToken);   
+            await _outputCacheStore.EvictByTagAsync(CacheConstants.MovieCacheTag, cancellationToken);
             return CreatedAtAction(nameof(Get), new { idOrSlug = movie.Id }, movie.MapToResponse());
         }
 
         [HttpGet(ApiEndpoints.Movies.GetAll)]
         [ProducesResponseType(typeof(PagedResponse<MovieResponse>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ValidationFailureResponse), StatusCodes.Status400BadRequest)]
-        [OutputCache(PolicyName = "MoviesCache")]
         // [ResponseCache(Duration = 30, VaryByQueryKeys = new[] { "title", "year", "sortBy", "page", "pageSize" }, VaryByHeader = "Accept, Accept-Encoding", Location = ResponseCacheLocation.Any)]
+        [OutputCache(PolicyName = CacheConstants.MovieCachePolicy)]
         public async Task<IActionResult> GetAll([FromQuery] GetAllMoviesRequest moviesRequest, CancellationToken cancellationToken)
         {
             var userId = HttpContext.GetUserId();
@@ -60,8 +60,8 @@ namespace Movies.Api.Controllers.V1
         [HttpGet(ApiEndpoints.Movies.Get)]
         [ProducesResponseType(typeof(MovieResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [OutputCache(PolicyName = "MovieCache")]
         // [ResponseCache(Duration = 30, VaryByHeader = "Accept, Accept-Encoding", Location = ResponseCacheLocation.Any)]
+        [OutputCache(PolicyName = CacheConstants.MovieCachePolicy)]
         public async Task<IActionResult> Get([FromRoute] string idOrSlug, CancellationToken cancellationToken)
         {
             var userId = HttpContext.GetUserId();
@@ -91,7 +91,7 @@ namespace Movies.Api.Controllers.V1
             {
                 return NotFound();
             }
-            await _outputCacheStore.EvictByTagAsync("movies", cancellationToken);
+            await _outputCacheStore.EvictByTagAsync(CacheConstants.MovieCacheTag, cancellationToken);
             return Ok(updatedMovie.MapToResponse());
         }
 
@@ -106,7 +106,7 @@ namespace Movies.Api.Controllers.V1
             {
                 return NotFound();
             }
-            await _outputCacheStore.EvictByTagAsync("movies", cancellationToken);
+            await _outputCacheStore.EvictByTagAsync(CacheConstants.MovieCacheTag, cancellationToken);
             return Ok();
         }
     }

--- a/Movies.Api/Program.cs
+++ b/Movies.Api/Program.cs
@@ -10,6 +10,7 @@ using Movies.Application;
 using Movies.Application.Database;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Movies.Api.Health;
+using Movies.Api.Cache;
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -65,12 +66,12 @@ builder.Services.AddApiVersioning(options =>
 builder.Services.AddOutputCache(options =>
 {
     options.AddBasePolicy(c => c.Cache());
-    options.AddPolicy("MovieCache", policy =>
+    options.AddPolicy(CacheConstants.MovieCachePolicy, policy =>
     {
         policy.Cache()
         .Expire(TimeSpan.FromMinutes(1))
-        .SetVaryByQuery(new[] { "title", "year", "sortBy", "page", "pageSize" })
-        .Tag("movies");
+        .SetVaryByQuery(CacheConstants.MovieCacheVaryByQueryParams)
+        .Tag(CacheConstants.MovieCacheTag);
     });
 });
 

--- a/Movies.Api/Program.cs
+++ b/Movies.Api/Program.cs
@@ -62,6 +62,17 @@ builder.Services.AddApiVersioning(options =>
 }).AddMvc().AddApiExplorer();
 
 //builder.Services.AddResponseCaching();
+builder.Services.AddOutputCache(options =>
+{
+    options.AddBasePolicy(c => c.Cache());
+    options.AddPolicy("MovieCache", policy =>
+    {
+        policy.Cache()
+        .Expire(TimeSpan.FromMinutes(1))
+        .SetVaryByQuery(new[] { "title", "year", "sortBy", "page", "pageSize" })
+        .Tag("movies");
+    });
+});
 
 builder.Services.AddControllers();
 
@@ -101,6 +112,7 @@ app.UseAuthorization();
 
 // app.UseCors()
 //app.UseResponseCaching();
+app.UseOutputCache();
 
 app.UseMiddleware<ValidationMappingMiddleware>();
 app.MapControllers();


### PR DESCRIPTION
- Add output cache middleware configuration
- Configure custom MovieCache policy with tag-based invalidation
- Apply caching policy to movie endpoints

@coderabbitai ignor & summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced output caching for movie listings and details, enhancing response speed.
- **Bug Fixes**
  - Automatically refreshes cached movie and rating data after create, update, delete, or rating changes to maintain data accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->