### PR TITLE
feat: Add multi-auth support with API key

### DIFF
--- a/Movies.Api/Auth/AdminAuthRequirement.cs
+++ b/Movies.Api/Auth/AdminAuthRequirement.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Movies.Api.Auth;
+
+public class AdminAuthRequirement : IAuthorizationHandler, IAuthorizationRequirement
+{
+    private readonly string _apiKey;
+
+public AdminAuthRequirement(string apiKey)
+    {
+        _apiKey = apiKey;
+    }
+    public Task HandleAsync(AuthorizationHandlerContext context)
+    {
+        if (context.User.HasClaim(AuthContstants.AdminUserClaimName, "true"))
+        {
+            context.Succeed(this);
+            return Task.CompletedTask;
+        }
+
+        var httpContext = context.Resource as HttpContext;
+        if (!httpContext.Request.Headers.TryGetValue(AuthContstants.ApiKeyHeaderName, out var extractedApiKey))
+        {
+            context.Fail();
+            return Task.CompletedTask;
+        }
+
+        if (_apiKey != extractedApiKey)
+        {
+            context.Fail();
+            return Task.CompletedTask;
+        }
+
+        var identity = (ClaimsIdentity)httpContext.User.Identity;
+        identity.AddClaim(new Claim("userid", Guid.Parse("d8566de3-b1a6-4a9b-b842-8e3887a82e43").ToString()));
+        context.Succeed(this);
+        return Task.CompletedTask;
+    }
+}

--- a/Movies.Api/Auth/ApiKeyAuthFilter.cs
+++ b/Movies.Api/Auth/ApiKeyAuthFilter.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Movies.Api.Auth;
+
+public class ApiKeyAuthFilter: IAuthorizationFilter
+{
+    private readonly IConfiguration _configuration;
+    public ApiKeyAuthFilter(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(AuthContstants.ApiKeyHeaderName, out var extractedApiKey))
+        {
+            context.Result = new UnauthorizedObjectResult("API Key Missing");
+            return;
+        }
+
+        var apiKey = _configuration.GetValue<string>("ApiKey");
+        if (apiKey != extractedApiKey)
+        {
+            context.Result = new UnauthorizedObjectResult("Invalid API Key");
+        }
+    }
+}

--- a/Movies.Api/Auth/AuthContstants.cs
+++ b/Movies.Api/Auth/AuthContstants.cs
@@ -9,4 +9,6 @@ public static class AuthContstants
 
     public const string TrusterMemberPolicyName = "TrustedMember";
     public const string TrusterMemberClaimName = "trusted_member";
+
+    public const string ApiKeyHeaderName = "x-api-key";
 }

--- a/Movies.Api/Controllers/V1/MoviesController.cs
+++ b/Movies.Api/Controllers/V1/MoviesController.cs
@@ -101,6 +101,7 @@ namespace Movies.Api.Controllers.V1
         [HttpDelete(ApiEndpoints.Movies.Delete)]
         public async Task<IActionResult> Delete([FromRoute] Guid id, CancellationToken cancellationToken)
         {
+            var userId = HttpContext.GetUserId();
             var deleted = await _movieService.DeleteByIdAsync(id, cancellationToken);
             if (!deleted)
             {

--- a/Movies.Api/Program.cs
+++ b/Movies.Api/Program.cs
@@ -11,6 +11,7 @@ using Movies.Application.Database;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Movies.Api.Health;
 using Movies.Api.Cache;
+using Movies.Api.Auth;
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -41,7 +42,7 @@ builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy(AuthContstants.AdminUserPolicyName, policy =>
     {
-        policy.RequireClaim(AuthContstants.AdminUserClaimName, "true");
+        policy.AddRequirements(new AdminAuthRequirement(config["ApiKey"]!));
     });
 
     options.AddPolicy(AuthContstants.TrusterMemberPolicyName, policy =>
@@ -52,6 +53,8 @@ builder.Services.AddAuthorization(options =>
         );
     });
 });
+
+builder.Services.AddScoped<ApiKeyAuthFilter>();
 
 // Configure API Versioning
 builder.Services.AddApiVersioning(options =>

--- a/Movies.Api/appsettings.json
+++ b/Movies.Api/appsettings.json
@@ -7,6 +7,7 @@
     "Issuer": "https://id.samschuddinck.be",
     "Audience": "https://movies.samschuddinck.be"
   },
+  "ApiKey": "fjeihfjebfbuhviofsbcaazeazvnfsdnjnfkze",
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- Add ApiKeyAuthFilter for API key based authentication
- Implement AdminAuthRequirement for dual auth support
- Update MoviesController to support both JWT and API key auth
- Configure API key authentication in Program.cs

@coderabbitai ignore

@coderabbitai summary